### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Avro support for JSON and other nested data structures.
 
 Rec-avro provides a generic Avro schema and converter functions that allow for storing nested python data structures in avro.
 
-Tested in Python 3 only.
+## Requirements
+Python version 3.6.x or higher
 
 ## Installation:
 ```sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Avro support for JSON and other nested data structures.
 
 Rec-avro provides a generic Avro schema and converter functions that allow for storing nested python data structures in avro.
 
-## Requirements
+## Requirements:
 Python version 3.6.x or higher
 
 ## Installation:


### PR DESCRIPTION
rec-avro cannot run on Python 3.5.x, by reason that syntax for variable annotations was added in Python version 3.6 or higher only