### PR TITLE
Small fix for case when '_' is missed in data

### DIFF
--- a/src/rec_avro/core.py
+++ b/src/rec_avro/core.py
@@ -126,7 +126,9 @@ def from_rec_avro_destructive(o):
         return o
 
     if isinstance(o, Mapping):
-        o = o['_']
+        if '_' in o:
+            o = o['_']
+
         if isinstance(o, Mapping):
             if isinstance(o, MutableMapping):
                 for k, v in o.items():


### PR DESCRIPTION
When we try put into `from_rec_avro_destructive/1` data without `"_"` field - will be error:
```sh
  File "/home/user/.local/lib/python3.6/site-packages/rec_avro/core.py", line 129, in from_rec_avro_destructive
    o = o['_']
KeyError: '_'
```
